### PR TITLE
Initialize Spring Boot GPU access backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
-# langtrainer-frontend
-Fronted / Firebase section of LLM based language training application.
+# Lang AI Cloud Backend
+
+Spring Boot backend service that manages controlled access to a locally hosted GPU for the language training AI frontend. This project exposes a REST API for monitoring GPU availability, requesting GPU sessions, and releasing them when clients are done.
+
+## Getting Started
+
+### Requirements
+
+* Java 17+
+* Maven 3.9+
+
+### Run the application
+
+```bash
+mvn spring-boot:run
+```
+
+The API will be available at `http://localhost:8080`.
+
+### Useful endpoints
+
+* `GET /api/gpu/status` &mdash; health-style overview of current GPU availability and active sessions.
+* `GET /api/gpu/sessions` &mdash; list all active GPU sessions managed by the service.
+* `POST /api/gpu/sessions` &mdash; request a new GPU session (requires JSON payload with `requestedBy` and optional `durationMinutes`).
+* `DELETE /api/gpu/sessions/{sessionId}` &mdash; release an existing GPU session.
+
+### Configuration
+
+You can configure concurrency and default session duration in `application.properties`:
+
+```properties
+gpu.max-concurrent-sessions=1
+gpu.default-session-minutes=30
+```
+
+These properties help ensure the GPU cannot be over-subscribed, and allow the backend to enforce sensible defaults when the frontend omits a duration.
+
+## Testing
+
+```bash
+mvn test
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.langai.cloud</groupId>
+    <artifactId>lang-ai-cloud</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>lang-ai-cloud</name>
+    <description>Backend service for managing GPU access for language training AI</description>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/langai/cloud/LangAiCloudApplication.java
+++ b/src/main/java/com/langai/cloud/LangAiCloudApplication.java
@@ -1,0 +1,14 @@
+package com.langai.cloud;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+@SpringBootApplication
+@ConfigurationPropertiesScan
+public class LangAiCloudApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(LangAiCloudApplication.class, args);
+    }
+}

--- a/src/main/java/com/langai/cloud/config/GpuAccessProperties.java
+++ b/src/main/java/com/langai/cloud/config/GpuAccessProperties.java
@@ -1,0 +1,33 @@
+package com.langai.cloud.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "gpu")
+public class GpuAccessProperties {
+
+    /**
+     * Maximum number of concurrent GPU sessions allowed.
+     */
+    private int maxConcurrentSessions = 1;
+
+    /**
+     * Default session duration in minutes when a client does not request a specific duration.
+     */
+    private int defaultSessionMinutes = 30;
+
+    public int getMaxConcurrentSessions() {
+        return maxConcurrentSessions;
+    }
+
+    public void setMaxConcurrentSessions(int maxConcurrentSessions) {
+        this.maxConcurrentSessions = maxConcurrentSessions;
+    }
+
+    public int getDefaultSessionMinutes() {
+        return defaultSessionMinutes;
+    }
+
+    public void setDefaultSessionMinutes(int defaultSessionMinutes) {
+        this.defaultSessionMinutes = defaultSessionMinutes;
+    }
+}

--- a/src/main/java/com/langai/cloud/controller/GpuAccessController.java
+++ b/src/main/java/com/langai/cloud/controller/GpuAccessController.java
@@ -1,0 +1,74 @@
+package com.langai.cloud.controller;
+
+import com.langai.cloud.dto.GpuSessionRequest;
+import com.langai.cloud.dto.GpuSessionResponse;
+import com.langai.cloud.dto.GpuStatusResponse;
+import com.langai.cloud.model.GpuSession;
+import com.langai.cloud.service.GpuAccessService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/gpu")
+public class GpuAccessController {
+
+    private final GpuAccessService gpuAccessService;
+
+    public GpuAccessController(GpuAccessService gpuAccessService) {
+        this.gpuAccessService = gpuAccessService;
+    }
+
+    @GetMapping("/status")
+    public GpuStatusResponse getStatus() {
+        return gpuAccessService.getStatus();
+    }
+
+    @GetMapping("/sessions")
+    public List<GpuSessionResponse> listSessions() {
+        return gpuAccessService.listActiveSessions().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @PostMapping("/sessions")
+    public ResponseEntity<GpuSessionResponse> createSession(@Valid @RequestBody GpuSessionRequest request) {
+        GpuSession session = gpuAccessService.createSession(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(session));
+    }
+
+    @DeleteMapping("/sessions/{sessionId}")
+    public ResponseEntity<Void> releaseSession(@PathVariable UUID sessionId) {
+        boolean removed = gpuAccessService.releaseSession(sessionId);
+        if (!removed) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found");
+        }
+        return ResponseEntity.noContent().build();
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<String> handleCapacityReached(IllegalStateException exception) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(exception.getMessage());
+    }
+
+    private GpuSessionResponse toResponse(GpuSession session) {
+        return new GpuSessionResponse(
+                session.getId(),
+                session.getRequestedBy(),
+                session.getCreatedAt(),
+                session.getExpiresAt()
+        );
+    }
+}

--- a/src/main/java/com/langai/cloud/dto/GpuSessionRequest.java
+++ b/src/main/java/com/langai/cloud/dto/GpuSessionRequest.java
@@ -1,0 +1,13 @@
+package com.langai.cloud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record GpuSessionRequest(
+        @NotBlank(message = "Requester name is required")
+        String requestedBy,
+
+        @PositiveOrZero(message = "Duration must be zero or a positive number of minutes")
+        int durationMinutes
+) {
+}

--- a/src/main/java/com/langai/cloud/dto/GpuSessionResponse.java
+++ b/src/main/java/com/langai/cloud/dto/GpuSessionResponse.java
@@ -1,0 +1,12 @@
+package com.langai.cloud.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record GpuSessionResponse(
+        UUID sessionId,
+        String requestedBy,
+        Instant createdAt,
+        Instant expiresAt
+) {
+}

--- a/src/main/java/com/langai/cloud/dto/GpuStatusResponse.java
+++ b/src/main/java/com/langai/cloud/dto/GpuStatusResponse.java
@@ -1,0 +1,10 @@
+package com.langai.cloud.dto;
+
+import java.time.Instant;
+
+public record GpuStatusResponse(
+        boolean available,
+        int activeSessions,
+        Instant lastUpdated
+) {
+}

--- a/src/main/java/com/langai/cloud/model/GpuSession.java
+++ b/src/main/java/com/langai/cloud/model/GpuSession.java
@@ -1,0 +1,34 @@
+package com.langai.cloud.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class GpuSession {
+    private final UUID id;
+    private final String requestedBy;
+    private final Instant createdAt;
+    private final Instant expiresAt;
+
+    public GpuSession(UUID id, String requestedBy, Instant createdAt, Instant expiresAt) {
+        this.id = id;
+        this.requestedBy = requestedBy;
+        this.createdAt = createdAt;
+        this.expiresAt = expiresAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getRequestedBy() {
+        return requestedBy;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+}

--- a/src/main/java/com/langai/cloud/service/GpuAccessService.java
+++ b/src/main/java/com/langai/cloud/service/GpuAccessService.java
@@ -1,0 +1,68 @@
+package com.langai.cloud.service;
+
+import com.langai.cloud.config.GpuAccessProperties;
+import com.langai.cloud.dto.GpuSessionRequest;
+import com.langai.cloud.dto.GpuStatusResponse;
+import com.langai.cloud.model.GpuSession;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class GpuAccessService {
+
+    private final GpuAccessProperties properties;
+    private final Map<UUID, GpuSession> activeSessions = new ConcurrentHashMap<>();
+
+    public GpuAccessService(GpuAccessProperties properties) {
+        this.properties = properties;
+    }
+
+    public GpuStatusResponse getStatus() {
+        purgeExpiredSessions();
+        boolean available = activeSessions.size() < properties.getMaxConcurrentSessions();
+        return new GpuStatusResponse(available, activeSessions.size(), Instant.now());
+    }
+
+    public Optional<GpuSession> findSession(UUID sessionId) {
+        purgeExpiredSessions();
+        return Optional.ofNullable(activeSessions.get(sessionId));
+    }
+
+    public GpuSession createSession(GpuSessionRequest request) {
+        purgeExpiredSessions();
+        if (activeSessions.size() >= properties.getMaxConcurrentSessions()) {
+            throw new IllegalStateException("GPU is currently at capacity");
+        }
+
+        int durationMinutes = request.durationMinutes() > 0
+                ? request.durationMinutes()
+                : properties.getDefaultSessionMinutes();
+
+        Instant now = Instant.now();
+        Instant expiresAt = now.plus(Duration.ofMinutes(durationMinutes));
+        GpuSession session = new GpuSession(UUID.randomUUID(), request.requestedBy(), now, expiresAt);
+        activeSessions.put(session.getId(), session);
+        return session;
+    }
+
+    public boolean releaseSession(UUID sessionId) {
+        return activeSessions.remove(sessionId) != null;
+    }
+
+    public Collection<GpuSession> listActiveSessions() {
+        purgeExpiredSessions();
+        return activeSessions.values();
+    }
+
+    private void purgeExpiredSessions() {
+        Instant now = Instant.now();
+        activeSessions.values().removeIf(session -> session.getExpiresAt().isBefore(now));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+spring.application.name=lang-ai-cloud
+
+# GPU access configuration
+# Adjust these values to match the capacity of the local machine hosting the GPU
+# gpu.max-concurrent-sessions=1
+# gpu.default-session-minutes=30

--- a/src/test/java/com/langai/cloud/LangAiCloudApplicationTests.java
+++ b/src/test/java/com/langai/cloud/LangAiCloudApplicationTests.java
@@ -1,0 +1,12 @@
+package com.langai.cloud;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class LangAiCloudApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- bootstrap a Spring Boot 3 project configured for Java 17
- add REST endpoints for monitoring GPU availability and managing GPU access sessions
- provide configurable limits for GPU sessions plus project documentation and tests

## Testing
- `mvn test` *(fails: unable to download parent POM because the environment cannot reach Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d40d379c2c832d81fd68912bac1c06